### PR TITLE
Make json_version 1 and 2 agnostic

### DIFF
--- a/keepalived_vrrp/src/cmk_addons_plugins/keepalived_vrrp/agent_based/keepalived_vrrp.py
+++ b/keepalived_vrrp/src/cmk_addons_plugins/keepalived_vrrp/agent_based/keepalived_vrrp.py
@@ -24,14 +24,17 @@ vrrp_states = {
 def parse_keepalived_vrrp(string_table):
     if len(string_table) == 0:
         return []
-    return json.loads(string_table[0][0])
+    section = json.loads(string_table[0][0])
+    if isinstance(section, list):
+        section=dict(vrrp=section)
+    return section
 
 def discover_keepalived_vrrp(section):
-    for instance in section:
+    for instance in section['vrrp']:
         yield Service(item=instance['data']['iname'])
 
 def check_keepalived_vrrp(item, section):
-    for instance in section:
+    for instance in section['vrrp']:
         if item == instance['data']['iname']:
             vrrp_state = instance['data']['state']
             if vrrp_state in vrrp_states:

--- a/keepalived_vrrp/src/cmk_addons_plugins/keepalived_vrrp/agent_based/keepalived_vrrp.py
+++ b/keepalived_vrrp/src/cmk_addons_plugins/keepalived_vrrp/agent_based/keepalived_vrrp.py
@@ -23,18 +23,18 @@ vrrp_states = {
 
 def parse_keepalived_vrrp(string_table):
     if len(string_table) == 0:
-        return []
+        return {}
     section = json.loads(string_table[0][0])
     if isinstance(section, list):
         section=dict(vrrp=section)
     return section
 
 def discover_keepalived_vrrp(section):
-    for instance in section['vrrp']:
+    for instance in section.get('vrrp', []):
         yield Service(item=instance['data']['iname'])
 
 def check_keepalived_vrrp(item, section):
-    for instance in section['vrrp']:
+    for instance in section.get('vrrp', []):
         if item == instance['data']['iname']:
             vrrp_state = instance['data']['state']
             if vrrp_state in vrrp_states:


### PR DESCRIPTION
The version 2 keepalived.json is a dictionary with the content of the version 1 available as the value of the vrrp entry. This was introduces in keepalived 2.2.8 https://github.com/acassen/keepalived/pull/2249