### PR TITLE
Improve the wait for keepalived.json to be ready

### DIFF
--- a/keepalived_vrrp/src/agents/plugins/keepalived_vrrp.sh
+++ b/keepalived_vrrp/src/agents/plugins/keepalived_vrrp.sh
@@ -19,7 +19,7 @@ fi
 kill -s $(keepalived --signum=JSON) $(<${KEEPALIVED_PIDFILE})
 # most of the times we need to wait a little bit until the json status file is created
 for i in {1..50}; do
-        if [ -e "${KEEPALIVED_STATUS_JSON}" ]; then
+        if [ -s "${KEEPALIVED_STATUS_JSON}" ]; then
                 break
         else
                 sleep 0.1

--- a/keepalived_vrrp/src/agents/plugins/keepalived_vrrp.sh
+++ b/keepalived_vrrp/src/agents/plugins/keepalived_vrrp.sh
@@ -15,8 +15,19 @@ fi
 if [ ! -e "${KEEPALIVED_PIDFILE}" ]; then
 	exit 0
 fi
+# Setup infotifywait
+INOTIFYWAIT=$(which inotifywait)
+if [ -x "${INOTIFYWAIT}" ]; then
+        $INOTIFYWAIT --timeout 5 --quiet --quiet\
+                --event CLOSE_WRITE \
+                --include $(basename $KEEPALIVED_STATUS_JSON) \
+                $(dirname $KEEPALIVED_STATUS_JSON) &
+        INOTIFY_PID=$!
+fi
 # send signal to keepalived
 kill -s $(keepalived --signum=JSON) $(<${KEEPALIVED_PIDFILE})
+# Wait for infotifywait
+if [ -n "${INOTIFY_PID}" ]; then wait $INOTIFY_PID; fi
 # most of the times we need to wait a little bit until the json status file is created
 for i in {1..50}; do
         if [ -s "${KEEPALIVED_STATUS_JSON}" ]; then


### PR DESCRIPTION
I encountered race conditions where the `keepalived.json` file was created but not ready. This lead to the service being checks as unknown from time to time.

* Stage one is to wait for the file to be non empty. This reduces the occurrence of the problem but not completely solved it.
* Stage two is to employ  the help of inotifywait to wait for the file to be closed after writing. While still working like before if inotifywait is not available.